### PR TITLE
fix: add configurationDefaults for Better Comments compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,16 @@
         "uiTheme": "vs-dark",
         "path": "./themes/gnome2like.json"
       }
-    ]
+    ],
+    "configurationDefaults": {
+      "better-comments.tags": [
+        {
+          "tag": "//",
+          "color": "#8090A0",
+          "strikethrough": false
+        }
+      ]
+    }
   },
   "devDependencies": {
     "@vscode/vsce": "^3.7.0",


### PR DESCRIPTION
## Summary
- Override Better Comments extension's default `//` tag color (#474747) which is hard to read on this dark theme
- Use `configurationDefaults` to set a readable color (#8090A0)

Fixes #2